### PR TITLE
feat: url link para google maps #75

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -34,7 +34,7 @@ export class Content {
     async map(data) {
         return data.conteudo.replace(
             /width.*[0-9];"/g, `width="100%" height="100%" style="aspect-ratio: 1; border: 0; border-radius: 5px;"`
-        )+`${data.extra ? '<button class="col button button-fill button-round"><a style="color:white;" class="link external" target="_blank" href="'+data.extra+'">Abrir no google maps</a></button>' : ''}`;
+        )+`${data.extra ? '<button class="col button button-fill button-round"><a style="color:white;" class="link external"  href="'+data.extra+'">Abrir no google maps</a></button>' : ''}`;
     }
 
     async video(data) {

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -34,7 +34,7 @@ export class Content {
     async map(data) {
         return data.conteudo.replace(
             /width.*[0-9];"/g, `width="100%" height="100%" style="aspect-ratio: 1; border: 0; border-radius: 5px;"`
-        )+`${data.extra ? '<button class="col button button-raised button-round"><a class="link external" href="'+data.extra+'">Abrir no google maps</a></button>' : ''}`;
+        )+`${data.extra ? '<button class="col button button-fill button-round"><a style="color:white;" class="link external" target="_blank" href="'+data.extra+'">Abrir no google maps</a></button>' : ''}`;
     }
 
     async video(data) {

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -34,7 +34,7 @@ export class Content {
     async map(data) {
         return data.conteudo.replace(
             /width.*[0-9];"/g, `width="100%" height="100%" style="aspect-ratio: 1; border: 0; border-radius: 5px;"`
-        )+`<button class="col button button-raised button-round"><a class="link external" href="${data.extra}">Abrir no google maps</a></button>`;
+        )+`${data.extra ? '<button class="col button button-raised button-round"><a class="link external" href="'+data.extra+'">Abrir no google maps</a></button>' : ''}`;
     }
 
     async video(data) {

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -33,7 +33,8 @@ export class Content {
 
     async map(data) {
         return data.conteudo.replace(
-            /width.*[0-9];"/g, `width="100%" height="100%" style="aspect-ratio: 1; border: 0; border-radius: 5px;"`);
+            /width.*[0-9];"/g, `width="100%" height="100%" style="aspect-ratio: 1; border: 0; border-radius: 5px;"`
+        )+`<button class="col button button-raised button-round"><a class="link external" href="${data.extra}">Abrir no google maps</a></button>`;
     }
 
     async video(data) {


### PR DESCRIPTION
Fix: #75 

Adicionei no campo extra o link da localização de chapecó do google maps ([linha 12](https://docs.google.com/spreadsheets/d/1lcsNj0vZzBjDdN31SBzMuz1VC6yuaxvSp5LVZ97WInY/edit#gid=444251642)) e um botão abaixo do Iframe do maps "Abrir no google maps" 

Vai ser necessário solicitar a equipe de conteúdo para revisar a planilha e onde existir uma linha referente ao mapa adicionar a mesma localização. Quando a Url não existir o botão não vai aparecer

![image](https://user-images.githubusercontent.com/29258164/173716468-e1462d1b-3b52-4dee-8a87-1d16eeb2b487.png)

![image](https://user-images.githubusercontent.com/29258164/173716528-1c83a914-8713-41ab-bfe5-ba3fddb5a303.png)

![image](https://user-images.githubusercontent.com/29258164/173716774-09c5a25d-80a6-4f21-b916-84148bd97d75.png)
